### PR TITLE
Update ElasticContentSaveHook.php

### DIFF
--- a/Classes/Hook/ElasticContentSaveHook.php
+++ b/Classes/Hook/ElasticContentSaveHook.php
@@ -75,10 +75,10 @@ class ElasticContentSaveHook
     public function processDatamap_afterDatabaseOperations($status, $table, $id, $fieldArray, $pObj)
     {
         if ($table === 'tt_content') {
-            if (strpos($id, 'NEW') !== false) {
+            if (strpos((string)$id, 'NEW') !== false) {
                 $id = $pObj->substNEWwithIDs[$id];
             }
-            $currentRecord = $this->typo3Services->backendUtilityGetRecord($table, $id);
+            $currentRecord = $this->typo3Services->backendUtilityGetRecord($table, (int)$id);
 
             if (!empty($currentRecord['header'])) {
                 $contentModel = new ContentDocument();


### PR DESCRIPTION
Typecast necessary for id twice. Otherwise TYPO3 will throw Uncaught Exceptions upon saving a Product record.